### PR TITLE
feat: 모임 채팅 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,6 +27,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/backend/src/main/java/momo/app/application/controller/ApplicationController.java
+++ b/backend/src/main/java/momo/app/application/controller/ApplicationController.java
@@ -6,6 +6,7 @@ import momo.app.application.dto.ApplicationCreateRequest;
 import momo.app.application.service.ApplicationCommandService;
 import momo.app.auth.dto.AuthUser;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,4 +25,13 @@ public class ApplicationController {
         return ResponseEntity.created(URI.create("/api/v1/applications/" + applicationId))
                 .build();
     }
+
+    @PostMapping("/{id}/approve")
+    public ResponseEntity<Void> approve(AuthUser authUser, @PathVariable Long id) {
+        applicationCommandService.approveApplication(authUser, id);
+
+        return ResponseEntity.ok()
+                .build();
+    }
+
 }

--- a/backend/src/main/java/momo/app/application/controller/ApplicationController.java
+++ b/backend/src/main/java/momo/app/application/controller/ApplicationController.java
@@ -6,6 +6,7 @@ import momo.app.application.dto.ApplicationCreateRequest;
 import momo.app.application.service.ApplicationCommandService;
 import momo.app.auth.dto.AuthUser;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,14 +21,18 @@ public class ApplicationController {
     private final ApplicationCommandService applicationCommandService;
 
     @PostMapping
-    public ResponseEntity<Void> create(AuthUser authUser, @RequestBody ApplicationCreateRequest request) {
+    public ResponseEntity<Void> create(
+            @RequestBody ApplicationCreateRequest request,
+            @AuthenticationPrincipal AuthUser authUser) {
         Long applicationId = applicationCommandService.createApplication(authUser, request);
         return ResponseEntity.created(URI.create("/api/v1/applications/" + applicationId))
                 .build();
     }
 
     @PostMapping("/{id}/approve")
-    public ResponseEntity<Void> approve(AuthUser authUser, @PathVariable Long id) {
+    public ResponseEntity<Void> approve(
+            @AuthenticationPrincipal AuthUser authUser,
+            @PathVariable Long id) {
         applicationCommandService.approveApplication(authUser, id);
 
         return ResponseEntity.ok()

--- a/backend/src/main/java/momo/app/application/controller/ApplicationController.java
+++ b/backend/src/main/java/momo/app/application/controller/ApplicationController.java
@@ -1,0 +1,27 @@
+package momo.app.application.controller;
+
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import momo.app.application.dto.ApplicationCreateRequest;
+import momo.app.application.service.ApplicationCommandService;
+import momo.app.auth.dto.AuthUser;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/applications")
+public class ApplicationController {
+
+    private final ApplicationCommandService applicationCommandService;
+
+    @PostMapping
+    public ResponseEntity<Void> create(AuthUser authUser, @RequestBody ApplicationCreateRequest request) {
+        Long applicationId = applicationCommandService.createApplication(authUser, request);
+        return ResponseEntity.created(URI.create("/api/v1/applications/" + applicationId))
+                .build();
+    }
+}

--- a/backend/src/main/java/momo/app/application/domain/Application.java
+++ b/backend/src/main/java/momo/app/application/domain/Application.java
@@ -1,0 +1,45 @@
+package momo.app.application.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import momo.app.gathering.domain.Gathering;
+import momo.app.user.domain.User;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Application {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private ApplicationStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "gathering_id")
+    private Gathering gathering;
+
+    @Builder
+    public Application(User user, Gathering gathering) {
+        this.user = user;
+        this.gathering = gathering;
+        this.status = ApplicationStatus.PENDING;
+    }
+}

--- a/backend/src/main/java/momo/app/application/domain/Application.java
+++ b/backend/src/main/java/momo/app/application/domain/Application.java
@@ -42,4 +42,8 @@ public class Application {
         this.gathering = gathering;
         this.status = ApplicationStatus.PENDING;
     }
+
+    public void approve() {
+        this.status = ApplicationStatus.APPROVED;
+    }
 }

--- a/backend/src/main/java/momo/app/application/domain/ApplicationRepository.java
+++ b/backend/src/main/java/momo/app/application/domain/ApplicationRepository.java
@@ -1,0 +1,6 @@
+package momo.app.application.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApplicationRepository extends JpaRepository<Application, Long> {
+}

--- a/backend/src/main/java/momo/app/application/domain/ApplicationRepository.java
+++ b/backend/src/main/java/momo/app/application/domain/ApplicationRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
 
-    @Query("select ap from Application ap join fetch Gathering g")
+    @Query("select ap from Application ap join fetch ap.gathering where ap.id = :id")
     Optional<Application> findByIdWithGathering(Long id);
 
 }

--- a/backend/src/main/java/momo/app/application/domain/ApplicationRepository.java
+++ b/backend/src/main/java/momo/app/application/domain/ApplicationRepository.java
@@ -1,6 +1,12 @@
 package momo.app.application.domain;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
+
+    @Query("select ap from Application ap join fetch Gathering g")
+    Optional<Application> findByIdWithGathering(Long id);
+
 }

--- a/backend/src/main/java/momo/app/application/domain/ApplicationStatus.java
+++ b/backend/src/main/java/momo/app/application/domain/ApplicationStatus.java
@@ -1,0 +1,16 @@
+package momo.app.application.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public enum ApplicationStatus {
+    PENDING("PENDING", "대기"),
+    APPROVED("APPROVED", "승인"),
+    REJECTED("REJECTED", "거절");
+
+    private String key;
+    private String value;
+}

--- a/backend/src/main/java/momo/app/application/dto/ApplicationCreateRequest.java
+++ b/backend/src/main/java/momo/app/application/dto/ApplicationCreateRequest.java
@@ -1,0 +1,4 @@
+package momo.app.application.dto;
+
+public record ApplicationCreateRequest(Long gatheringId) {
+}

--- a/backend/src/main/java/momo/app/application/exception/ApplicationErrorCode.java
+++ b/backend/src/main/java/momo/app/application/exception/ApplicationErrorCode.java
@@ -1,0 +1,32 @@
+package momo.app.application.exception;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import momo.app.common.error.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public enum ApplicationErrorCode implements ErrorCode {
+    NOT_FOUND_APPLICATION("7001", HttpStatus.BAD_REQUEST, "모임 신청 내역을 찾을 수 없습니다.");
+
+    private String code;
+    private HttpStatus status;
+    private String message;
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/backend/src/main/java/momo/app/application/service/ApplicationCommandService.java
+++ b/backend/src/main/java/momo/app/application/service/ApplicationCommandService.java
@@ -1,6 +1,7 @@
 package momo.app.application.service;
 
 import static momo.app.application.exception.ApplicationErrorCode.NOT_FOUND_APPLICATION;
+import static momo.app.chat.exception.ChatErrorCode.CHAT_ROOM_NOT_FOUND;
 import static momo.app.gathering.exception.GatheringErrorCode.GATHERING_NOT_FOUND;
 
 import lombok.RequiredArgsConstructor;
@@ -8,6 +9,11 @@ import momo.app.application.domain.Application;
 import momo.app.application.domain.ApplicationRepository;
 import momo.app.application.dto.ApplicationCreateRequest;
 import momo.app.auth.dto.AuthUser;
+import momo.app.chat.domain.chatroom.ChatRoom;
+import momo.app.chat.domain.chatroom.ChatRoomRepository;
+import momo.app.chat.domain.chatroom.ChatRoomUser;
+import momo.app.chat.domain.chatroom.ChatRoomUserRepository;
+import momo.app.chat.exception.ChatErrorCode;
 import momo.app.common.error.exception.BusinessException;
 import momo.app.gathering.domain.Gathering;
 import momo.app.gathering.domain.GatheringMember;
@@ -27,6 +33,8 @@ public class ApplicationCommandService {
     private final UserRepository userRepository;
     private final GatheringRepository gatheringRepository;
     private final GatheringMemberRepository gatheringMemberRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomUserRepository chatRoomUserRepository;
 
     public Long createApplication(AuthUser authUser, ApplicationCreateRequest request) {
         User user = findUser(authUser.getId());
@@ -49,6 +57,16 @@ public class ApplicationCommandService {
                 .gathering(gathering)
                 .user(user)
                 .build());
+        ChatRoom chatRoom = findChatRoom(gathering);
+        chatRoomUserRepository.save(ChatRoomUser.builder()
+                .chatRoom(chatRoom)
+                .user(user)
+                .build());
+    }
+
+    private ChatRoom findChatRoom(Gathering gathering) {
+        return chatRoomRepository.findById(gathering.getChatRoomId())
+                .orElseThrow(() -> new BusinessException(CHAT_ROOM_NOT_FOUND));
     }
 
     private Application findApplicationWithGathering(Long id) {

--- a/backend/src/main/java/momo/app/application/service/ApplicationCommandService.java
+++ b/backend/src/main/java/momo/app/application/service/ApplicationCommandService.java
@@ -1,0 +1,46 @@
+package momo.app.application.service;
+
+import static momo.app.gathering.exception.GatheringErrorCode.GATHERING_NOT_FOUND;
+
+import lombok.RequiredArgsConstructor;
+import momo.app.application.domain.Application;
+import momo.app.application.domain.ApplicationRepository;
+import momo.app.application.dto.ApplicationCreateRequest;
+import momo.app.auth.dto.AuthUser;
+import momo.app.common.error.exception.BusinessException;
+import momo.app.gathering.domain.Gathering;
+import momo.app.gathering.domain.GatheringRepository;
+import momo.app.user.domain.User;
+import momo.app.user.domain.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ApplicationCommandService {
+
+    private final ApplicationRepository applicationRepository;
+    private final UserRepository userRepository;
+    private final GatheringRepository gatheringRepository;
+
+    public Long createApplication(AuthUser authUser, ApplicationCreateRequest request) {
+        User user = findUser(authUser);
+        Gathering gathering = findGathering(request);
+        // TODO: 모임 정원 검증
+        return applicationRepository.save(Application.builder()
+                .user(user)
+                .gathering(gathering)
+                .build())
+                .getId();
+    }
+
+    private Gathering findGathering(ApplicationCreateRequest request) {
+        return gatheringRepository.findById(request.gatheringId())
+                .orElseThrow(() -> new BusinessException(GATHERING_NOT_FOUND));
+    }
+
+    private User findUser(AuthUser authUser) {
+        return userRepository.findById(authUser.getId())
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+    }
+
+}

--- a/backend/src/main/java/momo/app/application/service/ApplicationCommandService.java
+++ b/backend/src/main/java/momo/app/application/service/ApplicationCommandService.java
@@ -1,5 +1,6 @@
 package momo.app.application.service;
 
+import static momo.app.application.exception.ApplicationErrorCode.NOT_FOUND_APPLICATION;
 import static momo.app.gathering.exception.GatheringErrorCode.GATHERING_NOT_FOUND;
 
 import lombok.RequiredArgsConstructor;
@@ -9,22 +10,27 @@ import momo.app.application.dto.ApplicationCreateRequest;
 import momo.app.auth.dto.AuthUser;
 import momo.app.common.error.exception.BusinessException;
 import momo.app.gathering.domain.Gathering;
+import momo.app.gathering.domain.GatheringMember;
+import momo.app.gathering.domain.GatheringMemberRepository;
 import momo.app.gathering.domain.GatheringRepository;
 import momo.app.user.domain.User;
 import momo.app.user.domain.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class ApplicationCommandService {
 
     private final ApplicationRepository applicationRepository;
     private final UserRepository userRepository;
     private final GatheringRepository gatheringRepository;
+    private final GatheringMemberRepository gatheringMemberRepository;
 
     public Long createApplication(AuthUser authUser, ApplicationCreateRequest request) {
-        User user = findUser(authUser);
-        Gathering gathering = findGathering(request);
+        User user = findUser(authUser.getId());
+        Gathering gathering = findGathering(request.gatheringId());
         // TODO: 모임 정원 검증
         return applicationRepository.save(Application.builder()
                 .user(user)
@@ -33,14 +39,30 @@ public class ApplicationCommandService {
                 .getId();
     }
 
-    private Gathering findGathering(ApplicationCreateRequest request) {
-        return gatheringRepository.findById(request.gatheringId())
+    public void approveApplication(AuthUser authUser, Long id) {
+        User user = findUser(authUser.getId());
+        Application application = findApplicationWithGathering(id);
+        Gathering gathering = application.getGathering();
+        gathering.validateManager(authUser);
+        application.approve();
+        gatheringMemberRepository.save(GatheringMember.builder()
+                .gathering(gathering)
+                .user(user)
+                .build());
+    }
+
+    private Application findApplicationWithGathering(Long id) {
+        return applicationRepository.findByIdWithGathering(id)
+                .orElseThrow(() -> new BusinessException(NOT_FOUND_APPLICATION));
+    }
+
+    private Gathering findGathering(Long id) {
+        return gatheringRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(GATHERING_NOT_FOUND));
     }
 
-    private User findUser(AuthUser authUser) {
-        return userRepository.findById(authUser.getId())
+    private User findUser(Long id) {
+        return userRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
     }
-
 }

--- a/backend/src/main/java/momo/app/auth/jwt/service/JwtExtractService.java
+++ b/backend/src/main/java/momo/app/auth/jwt/service/JwtExtractService.java
@@ -42,6 +42,9 @@ public class JwtExtractService {
     //클라이언트 요청으로 refresh 토큰 header에서 추출
     public Optional<String> extractRefreshToken(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return Optional.empty();
+        }
         for (Cookie cookie : cookies) {
             if(refreshHeader.equals(cookie.getName())) {
                 return Optional.ofNullable(cookie.getValue());

--- a/backend/src/main/java/momo/app/chat/controller/ChatController.java
+++ b/backend/src/main/java/momo/app/chat/controller/ChatController.java
@@ -1,0 +1,23 @@
+package momo.app.chat.controller;
+
+import lombok.RequiredArgsConstructor;
+import momo.app.chat.dto.request.ChatMessageSendRequest;
+import momo.app.chat.service.ChatMessageCommandService;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final ChatMessageCommandService chatMessageCommandService;
+    private final SimpMessageSendingOperations sendingOperations;
+
+    @MessageMapping("/message")
+    public void sendMessage(@Payload ChatMessageSendRequest request) {
+        chatMessageCommandService.save(request);
+        sendingOperations.convertAndSend("/topic/chat-rooms/" + request.chatRoomId(), request);
+    }
+}

--- a/backend/src/main/java/momo/app/chat/controller/ChatController.java
+++ b/backend/src/main/java/momo/app/chat/controller/ChatController.java
@@ -1,11 +1,20 @@
 package momo.app.chat.controller;
 
 import lombok.RequiredArgsConstructor;
+import momo.app.auth.dto.AuthUser;
 import momo.app.chat.dto.request.ChatMessageSendRequest;
+import momo.app.chat.dto.response.ChatMessageResponse;
 import momo.app.chat.service.ChatMessageCommandService;
+import momo.app.chat.service.ChatMessageQueryService;
+import momo.app.common.dto.SliceResponse;
+import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -13,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatController {
 
     private final ChatMessageCommandService chatMessageCommandService;
+    private final ChatMessageQueryService chatMessageQueryService;
     private final SimpMessageSendingOperations sendingOperations;
 
     @MessageMapping("/message")
@@ -20,4 +30,15 @@ public class ChatController {
         chatMessageCommandService.save(request);
         sendingOperations.convertAndSend("/topic/chat-rooms/" + request.chatRoomId(), request);
     }
+
+    @GetMapping("/api/v1/chat-messages/chat-rooms/{id}")
+    public ResponseEntity<SliceResponse<ChatMessageResponse>> findMessages(
+            @AuthenticationPrincipal AuthUser authUser,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "20") int pageSize,
+            @PathVariable Long id
+    ) {
+        return ResponseEntity.ok(chatMessageQueryService.findAllChatMessages(id, authUser, cursor, pageSize));
+    }
+
 }

--- a/backend/src/main/java/momo/app/chat/domain/chatmessage/ChatMessage.java
+++ b/backend/src/main/java/momo/app/chat/domain/chatmessage/ChatMessage.java
@@ -1,0 +1,48 @@
+package momo.app.chat.domain.chatmessage;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import momo.app.chat.domain.chatroom.ChatRoom;
+import momo.app.user.domain.User;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 2048)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch =  FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id")
+    private ChatRoom chatRoom;
+
+    @Builder
+    public ChatMessage(
+            String content,
+            User user,
+            ChatRoom chatRoom
+    ) {
+        this.chatRoom =chatRoom;
+        this.user = user;
+        this.content = content;
+    }
+}

--- a/backend/src/main/java/momo/app/chat/domain/chatmessage/ChatMessageRepository.java
+++ b/backend/src/main/java/momo/app/chat/domain/chatmessage/ChatMessageRepository.java
@@ -1,0 +1,6 @@
+package momo.app.chat.domain.chatmessage;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+}

--- a/backend/src/main/java/momo/app/chat/domain/chatmessage/ChatMessageRepository.java
+++ b/backend/src/main/java/momo/app/chat/domain/chatmessage/ChatMessageRepository.java
@@ -1,6 +1,7 @@
 package momo.app.chat.domain.chatmessage;
 
+import momo.app.chat.infrastructure.ChatMessageRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>, ChatMessageRepositoryCustom {
 }

--- a/backend/src/main/java/momo/app/chat/domain/chatroom/ChatRoom.java
+++ b/backend/src/main/java/momo/app/chat/domain/chatroom/ChatRoom.java
@@ -32,12 +32,8 @@ public class ChatRoom {
     @OneToMany(mappedBy = "chatRoom")
     private List<ChatRoomUser> chatRoomUsers = new ArrayList<>();
 
-    @Column(nullable = false)
-    private boolean isActive;
-
     @Builder
     public ChatRoom(Long managerId) {
-        this.isActive = false;
         this.managerId = managerId;
     }
 }

--- a/backend/src/main/java/momo/app/chat/domain/chatroom/ChatRoom.java
+++ b/backend/src/main/java/momo/app/chat/domain/chatroom/ChatRoom.java
@@ -1,0 +1,43 @@
+package momo.app.chat.domain.chatroom;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import momo.app.chat.domain.chatmessage.ChatMessage;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long managerId;
+
+    @OneToMany(mappedBy = "chatRoom")
+    private List<ChatMessage> chatMessages = new ArrayList<>();
+
+    @OneToMany(mappedBy = "chatRoom")
+    private List<ChatRoomUser> chatRoomUsers = new ArrayList<>();
+
+    @Column(nullable = false)
+    private boolean isActive;
+
+    @Builder
+    public ChatRoom(Long managerId) {
+        this.isActive = false;
+        this.managerId = managerId;
+    }
+}

--- a/backend/src/main/java/momo/app/chat/domain/chatroom/ChatRoomRepository.java
+++ b/backend/src/main/java/momo/app/chat/domain/chatroom/ChatRoomRepository.java
@@ -1,6 +1,8 @@
 package momo.app.chat.domain.chatroom;
 
+import momo.app.chat.infrastructure.ChatRoomRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, ChatRoomRepositoryCustom {
+
 }

--- a/backend/src/main/java/momo/app/chat/domain/chatroom/ChatRoomRepository.java
+++ b/backend/src/main/java/momo/app/chat/domain/chatroom/ChatRoomRepository.java
@@ -1,0 +1,6 @@
+package momo.app.chat.domain.chatroom;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+}

--- a/backend/src/main/java/momo/app/chat/domain/chatroom/ChatRoomUser.java
+++ b/backend/src/main/java/momo/app/chat/domain/chatroom/ChatRoomUser.java
@@ -1,0 +1,38 @@
+package momo.app.chat.domain.chatroom;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import momo.app.user.domain.User;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoomUser {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id")
+    private ChatRoom chatRoom;
+
+    @Builder
+    public ChatRoomUser(User user, ChatRoom chatRoom) {
+        this.user = user;
+        this.chatRoom = chatRoom;
+    }
+}

--- a/backend/src/main/java/momo/app/chat/domain/chatroom/ChatRoomUserRepository.java
+++ b/backend/src/main/java/momo/app/chat/domain/chatroom/ChatRoomUserRepository.java
@@ -1,0 +1,6 @@
+package momo.app.chat.domain.chatroom;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomUserRepository extends JpaRepository<ChatRoomUser, Long> {
+}

--- a/backend/src/main/java/momo/app/chat/dto/request/ChatMessageSendRequest.java
+++ b/backend/src/main/java/momo/app/chat/dto/request/ChatMessageSendRequest.java
@@ -1,0 +1,8 @@
+package momo.app.chat.dto.request;
+
+public record ChatMessageSendRequest(
+        Long chatRoomId,
+        String content,
+        Long senderId
+) {
+}

--- a/backend/src/main/java/momo/app/chat/dto/response/ChatMessageResponse.java
+++ b/backend/src/main/java/momo/app/chat/dto/response/ChatMessageResponse.java
@@ -1,0 +1,13 @@
+package momo.app.chat.dto.response;
+
+public record ChatMessageResponse(
+        Long id,
+        String content,
+        Long senderId,
+        String senderName
+) {
+
+    public static ChatMessageResponse of(Long id, String content, Long memberId, String senderName) {
+        return new ChatMessageResponse(id, content, memberId, senderName);
+    }
+}

--- a/backend/src/main/java/momo/app/chat/exception/ChatErrorCode.java
+++ b/backend/src/main/java/momo/app/chat/exception/ChatErrorCode.java
@@ -1,0 +1,33 @@
+package momo.app.chat.exception;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import momo.app.common.error.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public enum ChatErrorCode implements ErrorCode {
+    CHAT_ROOM_NOT_FOUND("5001", HttpStatus.BAD_REQUEST, "채팅방이 없습니다."),
+    USER_NOT_IN_CHAT_ROOM("5002", HttpStatus.BAD_REQUEST, "채팅방에 없는 유저입니다.");
+
+    private String code;
+    private HttpStatus status;
+    private String message;
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/backend/src/main/java/momo/app/chat/infrastructure/ChatMessageRepositoryCustom.java
+++ b/backend/src/main/java/momo/app/chat/infrastructure/ChatMessageRepositoryCustom.java
@@ -1,0 +1,9 @@
+package momo.app.chat.infrastructure;
+
+import momo.app.chat.dto.response.ChatMessageResponse;
+import momo.app.common.dto.SliceResponse;
+
+public interface ChatMessageRepositoryCustom {
+
+    SliceResponse<ChatMessageResponse> findByChatRoomIdOrderByDesc(int pageSize, String cursor, Long id);
+}

--- a/backend/src/main/java/momo/app/chat/infrastructure/ChatMessageRepositoryImpl.java
+++ b/backend/src/main/java/momo/app/chat/infrastructure/ChatMessageRepositoryImpl.java
@@ -1,0 +1,83 @@
+package momo.app.chat.infrastructure;
+
+import static momo.app.chat.domain.chatmessage.QChatMessage.chatMessage;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import momo.app.chat.dto.response.ChatMessageResponse;
+import momo.app.common.dto.SliceResponse;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public SliceResponse<ChatMessageResponse> findByChatRoomIdOrderByDesc(
+            int pageSize,
+            String cursor,
+            Long id
+    ) {
+
+        List<ChatMessageResponse> result = jpaQueryFactory.select(Projections.constructor(
+                        ChatMessageResponse.class,
+                        chatMessage.id,
+                        chatMessage.content,
+                        chatMessage.user.id,
+                        chatMessage.user.name
+                ))
+                .from(chatMessage)
+                .where(isInRange(cursor), chatRoomIdEq(id))
+                .orderBy(chatMessage.id.desc())
+                .limit(pageSize + 1)
+                .fetch();
+
+        return convertToSlice(result, pageSize);
+    }
+
+    private SliceResponse<ChatMessageResponse> convertToSlice(
+            List<ChatMessageResponse>  chatMessageResponses,
+            int pageSize
+    ) {
+        boolean hasNext = existsNextValue(chatMessageResponses, pageSize);
+        String cursor = null;
+        if (hasNext) {
+            deleteLastValue(chatMessageResponses);
+            cursor = createNextCursor(chatMessageResponses);
+        }
+        return SliceResponse.of(chatMessageResponses, hasNext, cursor);
+    }
+
+    private String createNextCursor(List<ChatMessageResponse> chatMessageResponses) {
+        ChatMessageResponse chatMessageResponse = chatMessageResponses.get(chatMessageResponses.size() - 1);
+        return String.valueOf(chatMessageResponse.id());
+    }
+
+    private void deleteLastValue(List<ChatMessageResponse> chatMessageResponses) {
+        chatMessageResponses.remove(chatMessageResponses.size() - 1);
+    }
+
+    private boolean existsNextValue(List<ChatMessageResponse> chatMessageResponses, int pageSize) {
+        if (chatMessageResponses.size() > pageSize) {
+            return true;
+        }
+        return false;
+    }
+
+    private BooleanExpression chatRoomIdEq(Long id) {
+        return chatMessage.chatRoom.id.eq(id);
+    }
+
+    private BooleanExpression isInRange(String cursor) {
+        if (cursor == null) {
+            return null;
+        }
+
+        return chatMessage.id.lt(Long.valueOf(cursor));
+    }
+}

--- a/backend/src/main/java/momo/app/chat/infrastructure/ChatMessageRepositoryImpl.java
+++ b/backend/src/main/java/momo/app/chat/infrastructure/ChatMessageRepositoryImpl.java
@@ -63,10 +63,7 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
     }
 
     private boolean existsNextValue(List<ChatMessageResponse> chatMessageResponses, int pageSize) {
-        if (chatMessageResponses.size() > pageSize) {
-            return true;
-        }
-        return false;
+        return chatMessageResponses.size() > pageSize;
     }
 
     private BooleanExpression chatRoomIdEq(Long id) {

--- a/backend/src/main/java/momo/app/chat/infrastructure/ChatRoomRepositoryCustom.java
+++ b/backend/src/main/java/momo/app/chat/infrastructure/ChatRoomRepositoryCustom.java
@@ -1,0 +1,6 @@
+package momo.app.chat.infrastructure;
+
+public interface ChatRoomRepositoryCustom {
+
+    boolean existsBySenderIdAndChatRoomId(Long userId, Long chatRoomId);
+}

--- a/backend/src/main/java/momo/app/chat/infrastructure/ChatRoomRepositoryImpl.java
+++ b/backend/src/main/java/momo/app/chat/infrastructure/ChatRoomRepositoryImpl.java
@@ -1,0 +1,28 @@
+package momo.app.chat.infrastructure;
+
+import static momo.app.chat.domain.chatroom.QChatRoom.chatRoom;
+import static momo.app.chat.domain.chatroom.QChatRoomUser.chatRoomUser;
+import static momo.app.user.domain.QUser.user;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import momo.app.chat.domain.chatroom.ChatRoom;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public boolean existsBySenderIdAndChatRoomId(Long userId, Long chatRoomId) {
+        ChatRoom result = jpaQueryFactory.selectFrom(chatRoom)
+                .join(chatRoom.chatRoomUsers, chatRoomUser)
+                .join(chatRoomUser.user, user)
+                .where(chatRoom.id.eq(chatRoomId), chatRoom.managerId.eq(userId).or(user.id.eq(userId)))
+                .fetchFirst();
+
+        return result != null;
+    }
+}

--- a/backend/src/main/java/momo/app/chat/infrastructure/ChatRoomRepositoryImpl.java
+++ b/backend/src/main/java/momo/app/chat/infrastructure/ChatRoomRepositoryImpl.java
@@ -20,7 +20,7 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
         ChatRoom result = jpaQueryFactory.selectFrom(chatRoom)
                 .join(chatRoom.chatRoomUsers, chatRoomUser)
                 .join(chatRoomUser.user, user)
-                .where(chatRoom.id.eq(chatRoomId), chatRoom.managerId.eq(userId).or(user.id.eq(userId)))
+                .where(chatRoom.id.eq(chatRoomId).or(chatRoom.managerId.eq(userId).or(user.id.eq(userId))))
                 .fetchFirst();
 
         return result != null;

--- a/backend/src/main/java/momo/app/chat/infrastructure/ChatRoomRepositoryImpl.java
+++ b/backend/src/main/java/momo/app/chat/infrastructure/ChatRoomRepositoryImpl.java
@@ -4,6 +4,7 @@ import static momo.app.chat.domain.chatroom.QChatRoom.chatRoom;
 import static momo.app.chat.domain.chatroom.QChatRoomUser.chatRoomUser;
 import static momo.app.user.domain.QUser.user;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import momo.app.chat.domain.chatroom.ChatRoom;
@@ -20,9 +21,25 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
         ChatRoom result = jpaQueryFactory.selectFrom(chatRoom)
                 .join(chatRoom.chatRoomUsers, chatRoomUser)
                 .join(chatRoomUser.user, user)
-                .where(chatRoom.id.eq(chatRoomId).or(chatRoom.managerId.eq(userId).or(user.id.eq(userId))))
+                .where(chatRoomIdEq(chatRoomId)
+                                .and(isChatRoomManager(userId)
+                                        .or(isInChatRoom(userId))
+                                )
+                )
                 .fetchFirst();
 
         return result != null;
+    }
+
+    private BooleanExpression chatRoomIdEq(Long chatRoomId) {
+        return chatRoom.id.eq(chatRoomId);
+    }
+
+    private BooleanExpression isChatRoomManager(Long userId) {
+        return chatRoom.managerId.eq(userId);
+    }
+
+    private BooleanExpression isInChatRoom(Long userId) {
+        return user.id.eq(userId);
     }
 }

--- a/backend/src/main/java/momo/app/chat/service/ChatMessageCommandService.java
+++ b/backend/src/main/java/momo/app/chat/service/ChatMessageCommandService.java
@@ -1,0 +1,53 @@
+package momo.app.chat.service;
+
+import static momo.app.chat.exception.ChatErrorCode.CHAT_ROOM_NOT_FOUND;
+import static momo.app.chat.exception.ChatErrorCode.USER_NOT_IN_CHAT_ROOM;
+
+import lombok.RequiredArgsConstructor;
+import momo.app.chat.domain.chatmessage.ChatMessage;
+import momo.app.chat.domain.chatmessage.ChatMessageRepository;
+import momo.app.chat.domain.chatroom.ChatRoom;
+import momo.app.chat.domain.chatroom.ChatRoomRepository;
+import momo.app.chat.dto.request.ChatMessageSendRequest;
+import momo.app.common.error.exception.BusinessException;
+import momo.app.user.domain.User;
+import momo.app.user.domain.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChatMessageCommandService {
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final UserRepository userRepository;
+
+    public void save(ChatMessageSendRequest request) {
+        ChatRoom chatRoom = findChatRoom(request.chatRoomId());
+        validateMemberInChatRoom(request.senderId(), request.chatRoomId());
+        User sender = findUser(request.senderId());
+        chatMessageRepository.save(ChatMessage.builder()
+                .chatRoom(chatRoom)
+                .user(sender)
+                .content(request.content())
+                .build());
+    }
+
+    private User findUser(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+    }
+
+    private ChatRoom findChatRoom(Long chatRoomId) {
+        return chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new BusinessException(CHAT_ROOM_NOT_FOUND));
+    }
+
+    private void validateMemberInChatRoom(Long senderId, Long chatRoomId) {
+        if (!chatRoomRepository.existsBySenderIdAndChatRoomId(senderId, chatRoomId)) {
+            throw new BusinessException(USER_NOT_IN_CHAT_ROOM);
+        }
+    }
+}

--- a/backend/src/main/java/momo/app/chat/service/ChatMessageQueryService.java
+++ b/backend/src/main/java/momo/app/chat/service/ChatMessageQueryService.java
@@ -1,0 +1,37 @@
+package momo.app.chat.service;
+
+import static momo.app.chat.exception.ChatErrorCode.USER_NOT_IN_CHAT_ROOM;
+
+import lombok.RequiredArgsConstructor;
+import momo.app.auth.dto.AuthUser;
+import momo.app.chat.domain.chatmessage.ChatMessageRepository;
+import momo.app.chat.domain.chatroom.ChatRoomRepository;
+import momo.app.chat.dto.response.ChatMessageResponse;
+import momo.app.common.dto.SliceResponse;
+import momo.app.common.error.exception.BusinessException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageQueryService {
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomRepository chatRoomRepository;
+
+    public SliceResponse<ChatMessageResponse> findAllChatMessages(
+            Long id,
+            AuthUser authUser,
+            String cursor,
+            int pageSize
+    ) {
+        validateUserInChatRoom(id, authUser);
+        return chatMessageRepository.findByChatRoomIdOrderByDesc(pageSize, cursor, id);
+    }
+
+
+    private void validateUserInChatRoom(Long id, AuthUser authUser) {
+        if (!chatRoomRepository.existsBySenderIdAndChatRoomId(authUser.getId(), id)) {
+            throw new BusinessException(USER_NOT_IN_CHAT_ROOM);
+        }
+    }
+}

--- a/backend/src/main/java/momo/app/common/dto/SliceResponse.java
+++ b/backend/src/main/java/momo/app/common/dto/SliceResponse.java
@@ -1,0 +1,22 @@
+package momo.app.common.dto;
+
+import java.util.List;
+
+public record SliceResponse<T> (
+        List<T> values,
+        Boolean hasNext,
+        String cursor
+) {
+
+    public static <T> SliceResponse<T> of(
+            List<T> values,
+            Boolean hasNext,
+            String cursor
+    ) {
+        return new SliceResponse(
+                values,
+                hasNext,
+                cursor
+        );
+    }
+}

--- a/backend/src/main/java/momo/app/config/QuerydslConfig.java
+++ b/backend/src/main/java/momo/app/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package momo.app.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuerydslConfig {
+
+    private final EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/backend/src/main/java/momo/app/config/SecurityConfig.java
+++ b/backend/src/main/java/momo/app/config/SecurityConfig.java
@@ -42,10 +42,11 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/testTokens").permitAll()
+                        .requestMatchers("/api/v1/testTokens", "/ws").permitAll()
                         .requestMatchers("/v3/**", "swagger-ui/**").permitAll()
                         .requestMatchers("/api/v1/sign-up").hasRole("GUEST")
                         .requestMatchers("/api/v1/gatherings/**").hasRole("USER")
+                        .requestMatchers("/api/v1/applications/**").hasRole("USER")
                         .anyRequest().authenticated())
                 .exceptionHandling(exceptionHandlingConfigurer -> {
                     exceptionHandlingConfigurer.authenticationEntryPoint(jwtAuthenticationEntryPoint);

--- a/backend/src/main/java/momo/app/config/WebSocketConfig.java
+++ b/backend/src/main/java/momo/app/config/WebSocketConfig.java
@@ -1,0 +1,25 @@
+package momo.app.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.setApplicationDestinationPrefixes("/app");
+        registry.enableSimpleBroker("/queue", "/topic");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*");
+    }
+}
+
+

--- a/backend/src/main/java/momo/app/gathering/controller/GatheringController.java
+++ b/backend/src/main/java/momo/app/gathering/controller/GatheringController.java
@@ -35,7 +35,7 @@ public class GatheringController {
     ) {
 
         GatheringCreateRequest gatheringCreateRequest = GatheringCreateRequest.of(request, image);
-        Long id = gatheringCommandService.createGathering(gatheringCreateRequest, authUser);
+        Long id = gatheringCommandService.create(gatheringCreateRequest, authUser);
 
         return ResponseEntity.created(URI.create("/api/v1/gatherings/" + id))
                 .build();

--- a/backend/src/main/java/momo/app/gathering/domain/Gathering.java
+++ b/backend/src/main/java/momo/app/gathering/domain/Gathering.java
@@ -3,10 +3,13 @@ package momo.app.gathering.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -14,6 +17,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import momo.app.auth.dto.AuthUser;
+import momo.app.chat.domain.chatroom.ChatRoom;
 import momo.app.common.domain.BaseTime;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.SQLRestriction;
@@ -38,13 +42,21 @@ public class Gathering extends BaseTime {
     @ColumnDefault(value = "false")
     private boolean isDeleted;
 
+    @Column(nullable = false, unique = true)
+    private Long chatRoomId;
+
     @OneToMany(mappedBy = "gathering")
     private List<GatheringTag> gatheringTags = new ArrayList<>();
 
     @Builder
-    public Gathering(GatheringInfo gatheringInfo, Long managerId) {
+    public Gathering(
+            GatheringInfo gatheringInfo,
+            Long managerId,
+            Long chatRoomId
+    ) {
         this.gatheringInfo = gatheringInfo;
         this.managerId = managerId;
+        this.chatRoomId = chatRoomId;
     }
 
     public void addGatheringTag(GatheringTag gatheringTag) {

--- a/backend/src/main/java/momo/app/gathering/domain/Gathering.java
+++ b/backend/src/main/java/momo/app/gathering/domain/Gathering.java
@@ -1,15 +1,14 @@
 package momo.app.gathering.domain;
 
+import static momo.app.gathering.exception.GatheringErrorCode.NOT_MANAGER;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -17,8 +16,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import momo.app.auth.dto.AuthUser;
-import momo.app.chat.domain.chatroom.ChatRoom;
 import momo.app.common.domain.BaseTime;
+import momo.app.common.error.exception.BusinessException;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -65,7 +64,7 @@ public class Gathering extends BaseTime {
 
     public void validateManager(AuthUser authUser) {
         if (authUser.getId() != managerId) {
-            throw new IllegalStateException("Gathering can only be modified by the host.");
+            throw new BusinessException(NOT_MANAGER);
         }
     }
 

--- a/backend/src/main/java/momo/app/gathering/exception/GatheringErrorCode.java
+++ b/backend/src/main/java/momo/app/gathering/exception/GatheringErrorCode.java
@@ -1,0 +1,34 @@
+package momo.app.gathering.exception;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import momo.app.common.error.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public enum GatheringErrorCode implements ErrorCode {
+    GATHERING_NOT_FOUND("6001", HttpStatus.BAD_REQUEST, "모임방이 존재하지 않습니다."),
+    NOT_MANAGER("6002", HttpStatus.FORBIDDEN, "모임방의 메니저가 아닙니다.");
+
+
+    private String code;
+    private HttpStatus statue;
+    private String message;
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return statue;
+    }
+}

--- a/backend/src/main/java/momo/app/gathering/service/GatheringCommandService.java
+++ b/backend/src/main/java/momo/app/gathering/service/GatheringCommandService.java
@@ -1,6 +1,5 @@
 package momo.app.gathering.service;
 
-import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import momo.app.auth.dto.AuthUser;

--- a/backend/src/main/java/momo/app/gathering/service/GatheringCommandService.java
+++ b/backend/src/main/java/momo/app/gathering/service/GatheringCommandService.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import momo.app.auth.dto.AuthUser;
 import momo.app.chat.domain.chatroom.ChatRoom;
 import momo.app.chat.domain.chatroom.ChatRoomRepository;
+import momo.app.chat.domain.chatroom.ChatRoomUser;
+import momo.app.chat.domain.chatroom.ChatRoomUserRepository;
 import momo.app.gathering.domain.Gathering;
 import momo.app.gathering.domain.GatheringInfo;
 import momo.app.gathering.domain.GatheringMember;
@@ -34,6 +36,7 @@ public class GatheringCommandService {
     private final TagRepository tagRepository;
     private final GatheringTagRepository gatheringTagRepository;
     private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomUserRepository chatRoomUserRepository;
 
     public Long createGathering(GatheringCreateRequest request, AuthUser authUser) {
         User user = findUser(authUser.getId());
@@ -47,6 +50,11 @@ public class GatheringCommandService {
 
         ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.builder()
                 .managerId(authUser.getId())
+                .build());
+
+        chatRoomUserRepository.save(ChatRoomUser.builder()
+                .user(user)
+                .chatRoom(chatRoom)
                 .build());
 
         Gathering gathering = Gathering.builder()

--- a/backend/src/main/java/momo/app/gathering/service/GatheringCommandService.java
+++ b/backend/src/main/java/momo/app/gathering/service/GatheringCommandService.java
@@ -38,7 +38,7 @@ public class GatheringCommandService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomUserRepository chatRoomUserRepository;
 
-    public Long createGathering(GatheringCreateRequest request, AuthUser authUser) {
+    public Long create(GatheringCreateRequest request, AuthUser authUser) {
         User user = findUser(authUser.getId());
         String uploadedImageUrl = s3Service.upload(request.image());
         GatheringInfo gatheringInfo = GatheringInfo.of(

--- a/backend/src/main/java/momo/app/gathering/service/GatheringCommandService.java
+++ b/backend/src/main/java/momo/app/gathering/service/GatheringCommandService.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import momo.app.auth.dto.AuthUser;
+import momo.app.chat.domain.chatroom.ChatRoom;
+import momo.app.chat.domain.chatroom.ChatRoomRepository;
 import momo.app.gathering.domain.Gathering;
 import momo.app.gathering.domain.GatheringInfo;
 import momo.app.gathering.domain.GatheringMember;
@@ -32,6 +34,7 @@ public class GatheringCommandService {
     private final S3Service s3Service;
     private final TagRepository tagRepository;
     private final GatheringTagRepository gatheringTagRepository;
+    private final ChatRoomRepository chatRoomRepository;
 
     public Long createGathering(GatheringCreateRequest request, AuthUser authUser) {
         User user = findUser(authUser.getId());
@@ -42,9 +45,15 @@ public class GatheringCommandService {
                 request.description(),
                 uploadedImageUrl
         );
+
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.builder()
+                .managerId(authUser.getId())
+                .build());
+
         Gathering gathering = Gathering.builder()
                 .gatheringInfo(gatheringInfo)
                 .managerId(user.getId())
+                .chatRoomId(chatRoom.getId())
                 .build();
 
         gatheringRepository.save(gathering);


### PR DESCRIPTION
## 작업 사항

- [X] 모임 채팅 기능 구현 (개인 채팅은 아직X)
- [X] 기본적인 모임 참여, 승인 기능 구현
- [X] Querydsl 설정
-  close #60 
- close #59 
## 변경 사항
- [X] 인증 과정에서 쿠키 없는 경우 NullPointException 나는 문제 해결
## 주의 사항
최소한의 MVP만 우선 구현했어요. 그리고 아직 모임 초대, 초대 승인은 구현하지 않았어요.
모임 참여 신청 리스트 조회는 화면 정해지면 구현할게요 🙂
swagger, postman으로 기능 테스트는 다 했는데 다른 기능들 구현하면서 테스트 코드 같이 작성할게요!