### PR TITLE
feat: 모임 리스트 조회 기능 구현

### DIFF
--- a/backend/src/main/java/momo/app/gathering/controller/GatheringController.java
+++ b/backend/src/main/java/momo/app/gathering/controller/GatheringController.java
@@ -3,19 +3,26 @@ package momo.app.gathering.controller;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import momo.app.auth.dto.AuthUser;
+import momo.app.common.dto.SliceResponse;
+import momo.app.gathering.domain.Category;
+import momo.app.gathering.domain.GatheringSortType;
 import momo.app.gathering.dto.GatheringCreateJsonRequest;
 import momo.app.gathering.dto.GatheringCreateRequest;
+import momo.app.gathering.dto.GatheringResponse;
 import momo.app.gathering.dto.GatheringUpdateJsonRequest;
 import momo.app.gathering.dto.GatheringUpdateRequest;
 import momo.app.gathering.service.GatheringCommandService;
+import momo.app.gathering.service.GatheringQueryService;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -26,6 +33,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class GatheringController {
 
     private final GatheringCommandService gatheringCommandService;
+    private final GatheringQueryService gatheringQueryService;
 
     @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<Void> create(
@@ -39,6 +47,18 @@ public class GatheringController {
 
         return ResponseEntity.created(URI.create("/api/v1/gatherings/" + id))
                 .build();
+    }
+
+    @GetMapping
+    public ResponseEntity<SliceResponse<GatheringResponse>> findAll(
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "20") int pageSize,
+            @RequestParam(defaultValue = "LATEST") GatheringSortType sortType,
+            @RequestParam(required = false) Category category
+    ) {
+
+        SliceResponse<GatheringResponse> response = gatheringQueryService.findAll(cursor, pageSize, sortType, category);
+        return ResponseEntity.ok(response);
     }
 
     @PutMapping(value = "/{id}",

--- a/backend/src/main/java/momo/app/gathering/domain/GatheringSortType.java
+++ b/backend/src/main/java/momo/app/gathering/domain/GatheringSortType.java
@@ -2,14 +2,13 @@ package momo.app.gathering.domain;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public enum Category {
-    EXERCISE("EXERCISE", "운동"),
-    STUDY("STUDY", "공부"),
-    GAME("GAME", "게임"),
-    FOOD("FOOD", "음식"),
-    TRAVEL("TRAVEL", "여행");
+public enum GatheringSortType {
+    LATEST("LATEST", "최신순"),
+    MEMBER_COUNT("MEMBER_COUNT", "모임원순");
 
     private String key;
     private String value;

--- a/backend/src/main/java/momo/app/gathering/dto/GatheringResponse.java
+++ b/backend/src/main/java/momo/app/gathering/dto/GatheringResponse.java
@@ -1,0 +1,13 @@
+package momo.app.gathering.dto;
+
+import java.time.LocalDateTime;
+
+public record GatheringResponse(
+        Long id,
+        String name,
+        String description,
+        LocalDateTime createdAt,
+        String imageUrl,
+        int numberOfMembers
+) {
+}

--- a/backend/src/main/java/momo/app/gathering/infrastructure/GatheringRepositoryCustom.java
+++ b/backend/src/main/java/momo/app/gathering/infrastructure/GatheringRepositoryCustom.java
@@ -1,6 +1,14 @@
 package momo.app.gathering.infrastructure;
 
+import momo.app.common.dto.SliceResponse;
+import momo.app.gathering.domain.Category;
+import momo.app.gathering.domain.GatheringSortType;
+import momo.app.gathering.dto.GatheringResponse;
+
 public interface GatheringRepositoryCustom {
 
     boolean checkExistsByGatheringIdAndUserId(Long gatheringId, Long userId);
+
+    SliceResponse<GatheringResponse> findAllGatherings(
+            String cursor, int pageSize, GatheringSortType sortType, Category category);
 }

--- a/backend/src/main/java/momo/app/gathering/infrastructure/GatheringRepositoryImpl.java
+++ b/backend/src/main/java/momo/app/gathering/infrastructure/GatheringRepositoryImpl.java
@@ -1,16 +1,28 @@
 package momo.app.gathering.infrastructure;
 
+import static momo.app.gathering.domain.GatheringSortType.LATEST;
 import static momo.app.gathering.domain.QGathering.gathering;
 import static momo.app.gathering.domain.QGatheringMember.gatheringMember;
 
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import momo.app.common.dto.SliceResponse;
+import momo.app.gathering.domain.Category;
 import momo.app.gathering.domain.GatheringMember;
+import momo.app.gathering.domain.GatheringSortType;
+import momo.app.gathering.dto.GatheringResponse;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
 @Repository
 public class GatheringRepositoryImpl implements GatheringRepositoryCustom {
+
+    private static final int MAX_MEMBER_COUNT_DIGIT = 6;
 
     private final JPAQueryFactory jpaQueryFactory;
 
@@ -23,5 +35,100 @@ public class GatheringRepositoryImpl implements GatheringRepositoryCustom {
                 .fetchFirst();
 
         return result != null;
+    }
+
+    @Override
+    public SliceResponse<GatheringResponse> findAllGatherings(
+            String cursor,
+            int pageSize,
+            GatheringSortType sortType,
+            Category category
+    ) {
+        List<GatheringResponse> result = jpaQueryFactory.select(Projections.constructor(
+                        GatheringResponse.class,
+                        gathering.id,
+                        gathering.gatheringInfo.name,
+                        gathering.gatheringInfo.description,
+                        gathering.createdDate,
+                        gathering.gatheringInfo.imageUrl,
+                        gatheringMember.countDistinct().intValue()
+                ))
+                .from(gathering)
+                .leftJoin(gatheringMember).on(gatheringMember.gathering.id.eq(gathering.id))
+                .where(categoryEq(category))
+                .groupBy(gathering)
+                .having(isInSearchRange(cursor, sortType))
+                .orderBy(createGatheringSpecifier(sortType), gathering.id.desc())
+                .limit(pageSize + 1)
+                .fetch();
+
+        return convertToSlice(result, sortType, pageSize);
+    }
+
+    private BooleanExpression categoryEq(Category category) {
+        if (category != null) {
+            return gathering.gatheringInfo.category.eq(category);
+        }
+
+        return null;
+    }
+
+    private BooleanExpression isInSearchRange(String cursor, GatheringSortType sortType) {
+        if (cursor == null) {
+            return null;
+        }
+
+        if (sortType == LATEST) {
+            return gathering.id.lt(Long.valueOf(cursor));
+        }
+
+        int memberCount = Integer.parseInt(cursor.substring(0, MAX_MEMBER_COUNT_DIGIT));
+        long gatheringId = Long.parseLong(cursor.substring(MAX_MEMBER_COUNT_DIGIT));
+
+        return gathering.count().lt(memberCount)
+                .or(gathering.count().intValue().eq(memberCount).and(gathering.id.lt(gatheringId)));
+    }
+
+    private SliceResponse<GatheringResponse> convertToSlice(
+            List<GatheringResponse> result,
+            GatheringSortType sortType,
+            int pageSize
+    ) {
+        if (result.isEmpty()) {
+            return SliceResponse.of(result, false, null);
+        }
+
+        boolean hasNext = existNextPage(result, pageSize);
+        if (existNextPage(result, pageSize)) {
+            deleteLastPage(result, pageSize);
+        }
+
+        String nextCursor = generateCursor(result, sortType);
+        return SliceResponse.of(result, hasNext, nextCursor);
+    }
+
+    private boolean existNextPage(List<GatheringResponse> result, int pageSize) {
+        return result.size() > pageSize;
+    }
+
+    private void deleteLastPage(List<GatheringResponse> result, int pageSize) {
+        result.remove(pageSize);
+    }
+
+    private String generateCursor(List<GatheringResponse> result, GatheringSortType sortType) {
+        GatheringResponse lastGathering = result.get(result.size() - 1);
+
+        return switch (sortType) {
+            case MEMBER_COUNT -> String.format("%06d", lastGathering.numberOfMembers())
+                    + String.format("%08d", lastGathering.id());
+            default -> String.valueOf(lastGathering.id());
+        };
+    }
+
+    private OrderSpecifier createGatheringSpecifier(GatheringSortType sortType) {
+        return switch (sortType) {
+            case MEMBER_COUNT -> new OrderSpecifier<>(Order.DESC, gatheringMember.countDistinct());
+            default -> new OrderSpecifier<>(Order.DESC, gathering.id);
+        };
     }
 }

--- a/backend/src/main/java/momo/app/gathering/service/GatheringQueryService.java
+++ b/backend/src/main/java/momo/app/gathering/service/GatheringQueryService.java
@@ -1,0 +1,27 @@
+package momo.app.gathering.service;
+
+import lombok.RequiredArgsConstructor;
+import momo.app.common.dto.SliceResponse;
+import momo.app.gathering.domain.Category;
+import momo.app.gathering.domain.GatheringRepository;
+import momo.app.gathering.domain.GatheringSortType;
+import momo.app.gathering.dto.GatheringResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GatheringQueryService {
+
+    private final GatheringRepository gatheringRepository;
+
+    public SliceResponse<GatheringResponse> findAll(
+            String cursor,
+            int pageSize,
+            GatheringSortType sortType,
+            Category category
+    ) {
+
+        return gatheringRepository.findAllGatherings(cursor, pageSize, sortType, category);
+    }
+
+}


### PR DESCRIPTION
## 작업 사항

- [X] 모임 리스트 조회 기능 구현

## 변경 사항
- SortType 정의
- Category 추가

## 주의 사항
``` java
//응답 스펙 (SliceResponse)
List<T> values,
Boolean hasNext,
String cursor
```
Home 페이지에서 연결
최초 요청은 cursor에 값을 안 넣으시면 되고 두 번째 요청부터는 응답으로 받은 cursor를 쿼리 스트링에 붙여서 요청하면 돼요.
그리고 응답으로 받은 hasNext가 false 이면 마지막까지 다 조회된 거라 더 이상 요청 안되게 로직 구현하시면 돼요