### PR TITLE
feat: 최근 활동순 조회 로직 구현

### DIFF
--- a/backend/src/main/java/momo/app/chat/service/ChatMessageCommandService.java
+++ b/backend/src/main/java/momo/app/chat/service/ChatMessageCommandService.java
@@ -2,6 +2,7 @@ package momo.app.chat.service;
 
 import static momo.app.chat.exception.ChatErrorCode.CHAT_ROOM_NOT_FOUND;
 import static momo.app.chat.exception.ChatErrorCode.USER_NOT_IN_CHAT_ROOM;
+import static momo.app.gathering.exception.GatheringErrorCode.GATHERING_NOT_FOUND;
 
 import lombok.RequiredArgsConstructor;
 import momo.app.chat.domain.chatmessage.ChatMessage;
@@ -11,6 +12,8 @@ import momo.app.chat.domain.chatroom.ChatRoomRepository;
 import momo.app.chat.dto.request.ChatMessageSendRequest;
 import momo.app.chat.dto.response.ChatMessageResponse;
 import momo.app.common.error.exception.BusinessException;
+import momo.app.gathering.domain.Gathering;
+import momo.app.gathering.domain.GatheringRepository;
 import momo.app.user.domain.User;
 import momo.app.user.domain.UserRepository;
 import org.springframework.stereotype.Service;
@@ -24,11 +27,15 @@ public class ChatMessageCommandService {
     private final ChatMessageRepository chatMessageRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final UserRepository userRepository;
+    private final GatheringRepository gatheringRepository;
 
     public ChatMessageResponse save(ChatMessageSendRequest request) {
         ChatRoom chatRoom = findChatRoom(request.chatRoomId());
         validateMemberInChatRoom(request.senderId(), request.chatRoomId());
         User sender = findUser(request.senderId());
+        Gathering gathering = findGathering(request);
+        gathering.activate();
+
         ChatMessage chatMessage = chatMessageRepository.save(ChatMessage.builder()
                 .chatRoom(chatRoom)
                 .user(sender)
@@ -40,6 +47,11 @@ public class ChatMessageCommandService {
                 chatMessage.getContent(),
                 request.senderId(),
                 sender.getName());
+    }
+
+    private Gathering findGathering(ChatMessageSendRequest request) {
+        return gatheringRepository.findByChatRoomId(request.chatRoomId())
+                .orElseThrow(() -> new BusinessException(GATHERING_NOT_FOUND));
     }
 
     private User findUser(Long id) {

--- a/backend/src/main/java/momo/app/gathering/domain/Gathering.java
+++ b/backend/src/main/java/momo/app/gathering/domain/Gathering.java
@@ -4,6 +4,7 @@ import static momo.app.gathering.exception.GatheringErrorCode.NOT_MANAGER;
 
 import jakarta.persistence.*;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -40,6 +41,8 @@ public class Gathering extends BaseTime {
     @Column(nullable = false, unique = true)
     private Long chatRoomId;
 
+    private LocalDateTime lastActivityTime;
+
     @OneToMany(mappedBy = "gathering")
     private List<GatheringTag> gatheringTags = new ArrayList<>();
 
@@ -58,6 +61,7 @@ public class Gathering extends BaseTime {
         this.gatheringInfo = gatheringInfo;
         this.managerId = managerId;
         this.chatRoomId = chatRoomId;
+        this.lastActivityTime = LocalDateTime.now();
     }
 
     public void addGatheringTag(GatheringTag gatheringTag) {
@@ -77,5 +81,10 @@ public class Gathering extends BaseTime {
     public void updateGatheringInfo(GatheringInfo gatheringInfo) {
         this.gatheringInfo = gatheringInfo;
     }
+
+    public void activate() {
+        lastActivityTime = LocalDateTime.now();
+    }
+
 
 }

--- a/backend/src/main/java/momo/app/gathering/domain/GatheringRepository.java
+++ b/backend/src/main/java/momo/app/gathering/domain/GatheringRepository.java
@@ -1,5 +1,6 @@
 package momo.app.gathering.domain;
 
+import java.util.Optional;
 import momo.app.gathering.infrastructure.GatheringRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -10,4 +11,6 @@ public interface GatheringRepository extends JpaRepository<Gathering, Long>, Gat
     @Modifying(clearAutomatically = true)
     @Query("update Gathering g set g.isDeleted = true where g.id = :id")
     void deleteById(Long id);
+
+    Optional<Gathering> findByChatRoomId(Long chatRoomId);
 }

--- a/backend/src/main/java/momo/app/gathering/domain/GatheringSortType.java
+++ b/backend/src/main/java/momo/app/gathering/domain/GatheringSortType.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum GatheringSortType {
-    LATEST("LATEST", "최신순"),
+    LATEST("LATEST", "최신활동순"),
     MEMBER_COUNT("MEMBER_COUNT", "모임원순");
 
     private String key;

--- a/backend/src/main/java/momo/app/gathering/dto/GatheringResponse.java
+++ b/backend/src/main/java/momo/app/gathering/dto/GatheringResponse.java
@@ -7,6 +7,7 @@ public record GatheringResponse(
         String name,
         String description,
         LocalDateTime createdAt,
+        LocalDateTime lastActivityTime,
         String imageUrl,
         int numberOfMembers
 ) {

--- a/backend/src/main/java/momo/app/gathering/service/GatheringQueryService.java
+++ b/backend/src/main/java/momo/app/gathering/service/GatheringQueryService.java
@@ -7,8 +7,6 @@ import momo.app.common.error.exception.BusinessException;
 import momo.app.gathering.domain.Category;
 import momo.app.gathering.domain.GatheringRepository;
 import momo.app.gathering.domain.GatheringSortType;
-import momo.app.gathering.domain.GatheringMemberRepository;
-import momo.app.gathering.domain.Gathering;
 import momo.app.gathering.dto.GatheringResponse;
 import momo.app.gathering.dto.GatheringNameResponse;
 import momo.app.user.domain.User;
@@ -16,7 +14,6 @@ import momo.app.user.domain.UserRepository;
 import org.springframework.stereotype.Service;
 import java.util.List;
 
-import static momo.app.gathering.exception.GatheringErrorCode.GATHERING_NOT_FOUND;
 import static momo.app.user.exception.UserErrorCode.USER_NOT_FOUND;
 
 @Service
@@ -24,7 +21,6 @@ import static momo.app.user.exception.UserErrorCode.USER_NOT_FOUND;
 public class GatheringQueryService {
 
     private final GatheringRepository gatheringRepository;
-    private final GatheringMemberRepository gatheringMemberRepository;
     private final UserRepository userRepository;
 
     public SliceResponse<GatheringResponse> findAll(
@@ -40,11 +36,6 @@ public class GatheringQueryService {
     public List<GatheringNameResponse> getUserGathering(AuthUser authUser) {
         User user = findUser(authUser.getId());
         return gatheringRepository.findAllGatheringsByUser(user);
-    }
-
-    private Gathering findGathering(Long id) {
-        return gatheringRepository.findById(id)
-                .orElseThrow(() -> new BusinessException(GATHERING_NOT_FOUND));
     }
 
     private User findUser(Long id) {

--- a/backend/src/main/java/momo/app/schedule/domain/ScheduleRepository.java
+++ b/backend/src/main/java/momo/app/schedule/domain/ScheduleRepository.java
@@ -1,5 +1,6 @@
 package momo.app.schedule.domain;
 
+import java.util.Optional;
 import momo.app.gathering.domain.Gathering;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,4 +12,8 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     @Query("SELECT s FROM Schedule s WHERE s.gathering = :gathering")
     List<Schedule> findAllByGathering(Gathering gathering);
+
+    @Query("SELECT s FROM Schedule s JOIN FETCH s.gathering g WHERE s.id = :id")
+    Optional<Schedule> findByIdWithGathering(Long id);
+
 }

--- a/backend/src/main/java/momo/app/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/momo/app/schedule/service/ScheduleService.java
@@ -37,7 +37,7 @@ public class ScheduleService {
     ) {
         User user = findUser(authUser);
         Gathering gathering = findGathering(request.gatheringId());
-
+        gathering.activate();
         validateUserInGathering(request.gatheringId(), user);
 
         Schedule schedule = Schedule.builder()
@@ -61,7 +61,7 @@ public class ScheduleService {
             AuthUser authUser
     ) {
         User user = findUser(authUser);
-        Schedule schedule = findSchedule(id);
+        Schedule schedule = findScheduleWithGathering(id);
 
         schedule.validateUser(user);
 
@@ -81,8 +81,8 @@ public class ScheduleService {
     public void delete(Long id, AuthUser authUser) {
         User user = findUser(authUser);
         Schedule schedule = findSchedule(id);
-
         schedule.validateUser(user);
+        schedule.getGathering().activate();
 
         scheduleRepository.delete(schedule);
     }
@@ -99,6 +99,11 @@ public class ScheduleService {
 
     private Schedule findSchedule(Long id) {
         return scheduleRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(SCHEDULE_NOT_FOUND));
+    }
+
+    private Schedule findScheduleWithGathering(Long id) {
+        return scheduleRepository.findByIdWithGathering(id)
                 .orElseThrow(() -> new BusinessException(SCHEDULE_NOT_FOUND));
     }
 

--- a/backend/src/main/java/momo/app/vote/service/VoteCommandService.java
+++ b/backend/src/main/java/momo/app/vote/service/VoteCommandService.java
@@ -56,6 +56,8 @@ public class VoteCommandService {
                             .content(name)
                             .vote(vote)
                             .build()));
+        gathering.activate();
+
         return vote.getId();
     }
 


### PR DESCRIPTION
## 작업 사항

- [X] 최근 활동(투표, 채팅, 일정) 생성 시 기준으로 정렬되도록 로직 구현

## 변경 사항
Gathering 테이블에 마지막 활동 시간을 나타내는 필드 추가

## 주의 사항
프론트 채팅 기능쪽에 버그 발견해서 이거 우선적으로 수정할게요.
낮에 노트북 사용을 못해서 저녁밖에 시간이 없네요..ㅠㅠ 좀 늦어도 이해해주세요.